### PR TITLE
Twitter link in Social Media Box fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 
     <!-- Social Media Box Start -->
     <div class='box socialBox'>
-      <a href="https://twitter.com/WarwickTECH/lists/Partners/members" target="_blank" class="social twitter"><i
+      <a href="https://twitter.com/warwicktech" target="_blank" class="social twitter"><i
           class="fab fa-twitter"></i></a>
       <a href="https://medium.com/warwick-tech" target="_blank" class="social medium"><i
           class="fab fa-medium-m"></i></a>


### PR DESCRIPTION
The Twitter button in the social media box was originally directing to: https://twitter.com/WarwickTECH/lists/Partners/members
Changed it to direct to: https://twitter.com/warwicktech

(Sorry for creating a pull request, this has just been bugging me since I first went on the website)